### PR TITLE
Bug/app package name is not recognized by parser

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,12 +41,14 @@ android {
         debug {
             minifyEnabled false
             debuggable true
+            applicationIdSuffix ".android.github"
         }
 
         release {
             minifyEnabled true
             shrinkResources true
             debuggable false
+            applicationIdSuffix ".android.playmarket"
 
             if (signingConfigs.hasProperty("release")) {
                 signingConfig signingConfigs.release

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,11 +24,11 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
-        android:name=".App"
+        android:name="com.hypertrack.live.App"
         tools:ignore="GoogleAppIndexingWarning">
 
         <activity
-            android:name=".LaunchActivity"
+            android:name="com.hypertrack.live.LaunchActivity"
             android:label="@string/app_name"
             android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>
@@ -38,11 +38,11 @@
             </intent-filter>
         </activity>
         <activity
-            android:name=".ui.MainActivity"
+            android:name="com.hypertrack.live.ui.MainActivity"
             android:launchMode="singleInstance"
             android:theme="@style/AppTheme.NoActionBar" />
         <activity
-            android:name=".ui.VerificationActivity"
+            android:name="com.hypertrack.live.ui.VerificationActivity"
             android:screenOrientation="portrait"
             android:theme="@style/AppTheme.NoActionBar"
             android:windowSoftInputMode="adjustResize|stateHidden" />
@@ -54,7 +54,7 @@
         </service>
 
         <receiver
-            android:name=".InstallReferrerReceiver"
+            android:name="com.hypertrack.live.InstallReferrerReceiver"
             android:exported="true"
             android:permission="android.permission.INSTALL_PACKAGES">
             <intent-filter>
@@ -63,7 +63,7 @@
         </receiver>
 
         <receiver
-            android:name=".TrackingErrorReceiver"
+            android:name="com.hypertrack.live.TrackingErrorReceiver"
             android:exported="true">
             <intent-filter>
                 <action android:name="com.hypertrack.sdk.TRACKING_ERROR" />

--- a/app/src/main/java/com/hypertrack/live/InstallReferrerReceiver.java
+++ b/app/src/main/java/com/hypertrack/live/InstallReferrerReceiver.java
@@ -7,7 +7,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.text.TextUtils;
-import android.util.Log;
 
 public class InstallReferrerReceiver extends BroadcastReceiver {
     @SuppressLint("ApplySharedPref")

--- a/app/src/main/java/com/hypertrack/live/ui/VerificationActivity.java
+++ b/app/src/main/java/com/hypertrack/live/ui/VerificationActivity.java
@@ -1,26 +1,17 @@
 package com.hypertrack.live.ui;
 
 import android.app.Activity;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
-import android.provider.Settings;
 import android.text.TextUtils;
-import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
 
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 
-import com.hypertrack.live.utils.AppUtils;
 import com.hypertrack.live.R;
-import com.hypertrack.sdk.HyperTrack;
-import com.hypertrack.sdk.TrackingInitDelegate;
-import com.hypertrack.sdk.TrackingInitError;
 
 public class VerificationActivity extends AppCompatActivity {
     private static final String TAG = VerificationActivity.class.getSimpleName();

--- a/app/src/main/java/com/hypertrack/live/ui/WelcomeFragment.java
+++ b/app/src/main/java/com/hypertrack/live/ui/WelcomeFragment.java
@@ -4,7 +4,6 @@ import android.Manifest;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -17,9 +16,6 @@ import androidx.core.app.ActivityCompat;
 import androidx.fragment.app.Fragment;
 
 import com.hypertrack.live.R;
-import com.hypertrack.sdk.HyperTrack;
-import com.hypertrack.sdk.TrackingInitDelegate;
-import com.hypertrack.sdk.TrackingInitError;
 
 public class WelcomeFragment extends Fragment {
 


### PR DESCRIPTION
Part No 4 of hypertrack/issues#2006
Resulting app names will be `com.hypertrack.live.android.github` & `com.hypertrack.live.android.playmarket`
